### PR TITLE
Avoid overwriting dict in MultivariateToUnivariate

### DIFF
--- a/src/gift_eval/data.py
+++ b/src/gift_eval/data.py
@@ -96,9 +96,10 @@ class MultivariateToUnivariate(Transformation):
             item_id = data_entry["item_id"]
             val_ls = list(data_entry[self.field])
             for id, val in enumerate(val_ls):
-                data_entry[self.field] = val
-                data_entry["item_id"] = item_id + "_dim" + str(id)
-                yield data_entry
+                univariate_entry = data_entry.copy()
+                univariate_entry[self.field] = val
+                univariate_entry["item_id"] = item_id + "_dim" + str(id)
+                yield univariate_entry
 
 
 class Dataset:


### PR DESCRIPTION
This PR updates `MultivariateToUnivariate` to use a copy of the entry instead of modifying the original data entry. Updating the original entry can lead to unexpected behavior when working with the dataset. 