### PR TITLE
feat: relax pandas dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "pandas==2.0.0",
+  "pandas>=2.0.0",
   "gluonts~=0.15.1",
   "numpy~=1.26.0",
   "einops==0.7.*",

--- a/src/gift_eval/data.py
+++ b/src/gift_eval/data.py
@@ -51,7 +51,6 @@ PRED_LENGTH_MAP = {
     "H": 48,
     "T": 48,
     "S": 60,
-    "h": 48,
 }
 
 TFB_PRED_LENGTH_MAP = {
@@ -84,6 +83,23 @@ class Term(Enum):
 def itemize_start(data_entry: DataEntry) -> DataEntry:
     data_entry["start"] = data_entry["start"].item()
     return data_entry
+
+
+def maybe_reconvert_freq(freq: str) -> str:
+    """if the freq is one of the newest pandas freqs, convert it to the old freq"""
+    deprecated_map = {
+        "Y": "A",
+        "YE": "A",
+        "QE": "Q",
+        "ME": "M",
+        "h": "H",
+        "min": "T",
+        "s": "S",
+        "us": "U",
+    }
+    if freq in deprecated_map:
+        return deprecated_map[freq]
+    return freq
 
 
 class MultivariateToUnivariate(Transformation):
@@ -133,6 +149,7 @@ class Dataset:
     @cached_property
     def prediction_length(self) -> int:
         freq = norm_freq_str(to_offset(self.freq).name)
+        freq = maybe_reconvert_freq(freq)
         pred_len = (
             M4_PRED_LENGTH_MAP[freq] if "m4" in self.name else PRED_LENGTH_MAP[freq]
         )

--- a/src/gift_eval/data.py
+++ b/src/gift_eval/data.py
@@ -51,6 +51,7 @@ PRED_LENGTH_MAP = {
     "H": 48,
     "T": 48,
     "S": 60,
+    "h": 48,
 }
 
 TFB_PRED_LENGTH_MAP = {


### PR DESCRIPTION
this pr relaxes the required pandas version by adding the `maybe_reconvert_freq` function, which reconverts the frequency generated by `norm_freq_str(to_offset(self.freq).name)` to a supported map if needed. tested against the naive notebook.