### PR TITLE
Update TiRex to always use the cuda backend

### DIFF
--- a/notebooks/tirex.ipynb
+++ b/notebooks/tirex.ipynb
@@ -19,7 +19,7 @@
     "1. **Install in conda environment**\n",
     "\n",
     "```bash\n",
-    "conda create python=3.11 pip cuda=12.4 cuda-nvcc=12.4 gxx_linux-64=11.4.0 compilers cmake ninja cuda-toolkit=12.4 cuda-cccl=12.4 --name tirex\n",
+    "conda create -c conda-forge python=3.11 pip cuda=12.4 cuda-nvcc=12.4 gxx_linux-64=11.4.0 compilers cmake ninja cuda-toolkit=12.4 cuda-cccl=12.4 --name tirex\n",
     "conda activate tirex\n",
     "```\n",
     "\n",


### PR DESCRIPTION
Due to the increased interest in measuring and comparing the execution time of different models, we've updated our notebook to always use our fastest backend that's based on our custom CUDA extension.