### PR TITLE
Fix infer_period to raise ValueError instead of AttributeError for unmatched alphanumeric freqs

### DIFF
--- a/src/gift_eval/analysis/features.py
+++ b/src/gift_eval/analysis/features.py
@@ -33,6 +33,8 @@ def infer_period(freq):
     elif freq.isalnum():
         pattern = r"(\d+)([a-zA-Z]+)"
         match = re.match(pattern, freq)
+        if match is None:
+            raise ValueError(f"Frequency {freq} not recognized")
         repeat_count, freq_str = match.groups()
         return max(PERIODS[freq_str]//int(repeat_count), 1)
     else:


### PR DESCRIPTION
Fixes #135

`infer_period` documents `ValueError` for unrecognized frequencies, but the `elif freq.isalnum():` branch crashes with `AttributeError` for any alphanumeric string that does not begin with digits (e.g. `"FOO"`, `"2"`, `"abc123"`). The regex `(\d+)([a-zA-Z]+)` returns `None` for those, and `match.groups()` then blows up. Adding a `None` check makes the function honor its own docstring.

Before:
```
>>> infer_period("FOO")
AttributeError: 'NoneType' object has no attribute 'groups'
```

After:
```
>>> infer_period("FOO")
ValueError: Frequency FOO not recognized
```

Valid frequencies still resolve correctly: `H` -> 24, `2H` -> 12, `2A-DEC` -> 1.
