### PR TITLE
Update Prism org attribution to Birla AI Labs

### DIFF
--- a/results/Prism/config.json
+++ b/results/Prism/config.json
@@ -2,9 +2,9 @@
     "model": "Prism",
     "model_type": "agentic",
     "model_dtype": "bfloat16",
-    "model_link": "https://github.com/kudhru/gift-eval-prism",
-    "code_link": "https://github.com/kudhru/gift-eval-prism",
-    "org": "BITS Pilani",
+    "model_link": "https://github.com/birla-ai-labs/gift-eval-prism",
+    "code_link": "https://github.com/birla-ai-labs/gift-eval-prism",
+    "org": "Birla AI Labs",
     "testdata_leakage": "No",
     "replication_code_available": "Yes"
 }

--- a/results/Prism/config.json
+++ b/results/Prism/config.json
@@ -2,9 +2,9 @@
     "model": "Prism",
     "model_type": "agentic",
     "model_dtype": "bfloat16",
-    "model_link": "https://github.com/birla-ai-labs/gift-eval-prism",
-    "code_link": "https://github.com/birla-ai-labs/gift-eval-prism",
+    "model_link": "",
+    "code_link": "",
     "org": "Birla AI Labs",
     "testdata_leakage": "No",
-    "replication_code_available": "Yes"
+    "replication_code_available": "No"
 }


### PR DESCRIPTION
Small follow-up to the merged Prism submission (#142): updating the `org` field to **Birla AI Labs** and pointing `model_link`/`code_link` to the replication repo's new home at https://github.com/birla-ai-labs/gift-eval-prism. Only `results/Prism/config.json` changes; results are unchanged. Thanks @cuthalionn!