### PR TITLE
Add .cursor/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,4 @@ fabric.properties
 .idea/caches/build_file_checksums.ser
 .vscode/launch.json
 
+.cursor/


### PR DESCRIPTION
## Summary
- Ignore the local `.cursor/` directory so editor/agent workspace files aren't accidentally committed.

## Test plan
- N/A (gitignore-only change)

Made with [Cursor](https://cursor.com)