### PR TITLE
Correct org field for FastCastrage

### DIFF
--- a/results/FastCastrage/config.json
+++ b/results/FastCastrage/config.json
@@ -4,7 +4,7 @@
     "model_dtype": "float32",
     "model_link": "",
     "code_link": "",
-    "org": "TW3 Partners",
+    "org": "sme",
     "testdata_leakage": "No",
     "replication_code_available": "No"
 }


### PR DESCRIPTION
One-line correction to `results/FastCastrage/config.json`: the `org` field is wrong for this submission and should read `sme`.

No results, metrics or rankings are affected — only the Organization column of the leaderboard.

We would be grateful if this could be merged (and reflected on the Space) promptly, as the current value misattributes the submission. Thanks a lot for maintaining the benchmark.