### PR TITLE
Update CastStar model link

### DIFF
--- a/results/CastStar/config.json
+++ b/results/CastStar/config.json
@@ -2,7 +2,7 @@
   "model": "CastStar",
   "model_type": "agentic",
   "model_dtype": "float32",
-  "model_link": "https://huggingface.co/USTC-AGI/CastStar",
+  "model_link": "https://arxiv.org/abs/2602.01776",
   "org": "USTC-AGI",
   "testdata_leakage": "No",
   "replication_code_available": "No"


### PR DESCRIPTION
## Description

This PR updates the `model_link` for CastStar to the corresponding arXiv paper:

https://arxiv.org/abs/2602.01776

No evaluation results or other configuration fields are changed.